### PR TITLE
Correctly parse all valid test cases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "demes-spec"]
-	path = tools/demes-spec
-	url = https://github.com/popsim-consortium/demes-spec.git

--- a/R/helper.R
+++ b/R/helper.R
@@ -60,12 +60,12 @@ order_demes <- function(deme) {
   return(ordered_deme)
 }
 
-conv_prop_vec <- function(demes){
+conv_prop_list <- function(demes){
   for (i in 1:length(demes$demes)){
     if (length(demes$demes[[i]]$proportions) > 0){
-      demes$demes[[i]]$proportions <- as.double(unlist(demes$demes[[i]]$proportions))
+      demes$demes[[i]]$proportions <- list(as.double(demes$demes[[i]]$proportions))
     } else{
-      demes$demes[[i]]$proportions <- vector(mode="double")
+      demes$demes[[i]]$proportions <- list()
     }
   }
 
@@ -86,7 +86,7 @@ conv_migr <- function(demes){
 post_process_expected <- function(exp){
   exp <- order_demes(exp)
   exp <- convert_infinity(exp)
-  #exp <- conv_prop_vec(exp)
+  exp <- conv_prop_list(exp)
   exp <- conv_migr(exp)
 
   return(exp)

--- a/R/helper.R
+++ b/R/helper.R
@@ -16,15 +16,17 @@ order_demes <- function(deme) {
     ordered_deme$demes[[i]]$start_time <- deme$demes[[i]]$start_time
 
     ordered_deme$demes[[i]]$epochs <- list()
-    for (j in 1:length(deme$demes[[i]]$epochs)){
-      ordered_deme$demes[[i]]$epochs[j][[1]] <- list()
+    if (length(deme$demes[[i]]$epochs) > 0){
+      for (j in 1:length(deme$demes[[i]]$epochs)){
+        ordered_deme$demes[[i]]$epochs[j][[1]] <- list()
 
-      ordered_deme$demes[[i]]$epochs[[j]]$end_time <- deme$demes[[i]]$epochs[[j]]$end_time
-      ordered_deme$demes[[i]]$epochs[[j]]$start_size <- deme$demes[[i]]$epochs[[j]]$start_size
-      ordered_deme$demes[[i]]$epochs[[j]]$end_size <- deme$demes[[i]]$epochs[[j]]$end_size
-      ordered_deme$demes[[i]]$epochs[[j]]$size_function <- deme$demes[[i]]$epochs[[j]]$size_function
-      ordered_deme$demes[[i]]$epochs[[j]]$selfing_rate <- deme$demes[[i]]$epochs[[j]]$selfing_rate
-      ordered_deme$demes[[i]]$epochs[[j]]$cloning_rate <- deme$demes[[i]]$epochs[[j]]$cloning_rate
+        ordered_deme$demes[[i]]$epochs[[j]]$end_time <- deme$demes[[i]]$epochs[[j]]$end_time
+        ordered_deme$demes[[i]]$epochs[[j]]$start_size <- deme$demes[[i]]$epochs[[j]]$start_size
+        ordered_deme$demes[[i]]$epochs[[j]]$end_size <- deme$demes[[i]]$epochs[[j]]$end_size
+        ordered_deme$demes[[i]]$epochs[[j]]$size_function <- deme$demes[[i]]$epochs[[j]]$size_function
+        ordered_deme$demes[[i]]$epochs[[j]]$selfing_rate <- deme$demes[[i]]$epochs[[j]]$selfing_rate
+        ordered_deme$demes[[i]]$epochs[[j]]$cloning_rate <- deme$demes[[i]]$epochs[[j]]$cloning_rate
+      }
     }
     ordered_deme$demes[[i]]$proportions <- deme$demes[[i]]$proportions
     ordered_deme$demes[[i]]$ancestors <- deme$demes[[i]]$ancestors

--- a/R/helper.R
+++ b/R/helper.R
@@ -60,12 +60,18 @@ order_demes <- function(deme) {
   return(ordered_deme)
 }
 
-conv_prop_list <- function(demes){
+conv_prop_anc_vec <- function(demes){
   for (i in 1:length(demes$demes)){
     if (length(demes$demes[[i]]$proportions) > 0){
-      demes$demes[[i]]$proportions <- list(as.double(demes$demes[[i]]$proportions))
+      demes$demes[[i]]$proportions <- as.double(demes$demes[[i]]$proportions)
     } else{
-      demes$demes[[i]]$proportions <- list()
+      demes$demes[[i]]$proportions <- vector(mode="double")
+    }
+
+    if (length(demes$demes[[i]]$ancestors) > 0){
+      demes$demes[[i]]$ancestors <- unlist(demes$demes[[i]]$ancestors)
+    } else{
+      demes$demes[[i]]$ancestors <- vector(mode="character")
     }
   }
 
@@ -86,7 +92,7 @@ conv_migr <- function(demes){
 post_process_expected <- function(exp){
   exp <- order_demes(exp)
   exp <- convert_infinity(exp)
-  exp <- conv_prop_list(exp)
+  exp <- conv_prop_anc_vec(exp)
   exp <- conv_migr(exp)
 
   return(exp)

--- a/R/helper.R
+++ b/R/helper.R
@@ -13,6 +13,8 @@ order_demes <- function(deme) {
 
     ordered_deme$demes[[i]]$name <- deme$demes[[i]]$name
     ordered_deme$demes[[i]]$description <- deme$demes[[i]]$description
+    ordered_deme$demes[[i]]$ancestors <- deme$demes[[i]]$ancestors
+    ordered_deme$demes[[i]]$proportions <- deme$demes[[i]]$proportions
     ordered_deme$demes[[i]]$start_time <- deme$demes[[i]]$start_time
 
     ordered_deme$demes[[i]]$epochs <- list()
@@ -28,8 +30,6 @@ order_demes <- function(deme) {
         ordered_deme$demes[[i]]$epochs[[j]]$cloning_rate <- deme$demes[[i]]$epochs[[j]]$cloning_rate
       }
     }
-    ordered_deme$demes[[i]]$proportions <- deme$demes[[i]]$proportions
-    ordered_deme$demes[[i]]$ancestors <- deme$demes[[i]]$ancestors
   }
 
   ordered_deme$migrations <- list()
@@ -72,10 +72,22 @@ conv_prop_vec <- function(demes){
   return(demes)
 }
 
+conv_migr <- function(demes){
+  if (length(demes$migrations) > 0){
+    for (j in 1:length(demes$migrations)){
+      if (length(demes$migrations[[j]]) > 0){
+        demes$migrations[[j]]$rate <- as.double(demes$migrations[[j]]$rate)
+      }
+    }
+  }
+  return(demes)
+}
+
 post_process_expected <- function(exp){
   exp <- order_demes(exp)
   exp <- convert_infinity(exp)
-  exp <- conv_prop_vec(exp)
+  #exp <- conv_prop_vec(exp)
+  exp <- conv_migr(exp)
 
   return(exp)
 }

--- a/R/name_demes.R
+++ b/R/name_demes.R
@@ -3,7 +3,7 @@
 name_demes <- function(demes){
   deme_names <- c()
   for (i in 1:length(demes$demes)){
-    deme_names[i] <- demes$demes[[1]]$name
+    deme_names[i] <- demes$demes[[i]]$name
   }
   names(demes$demes) <- deme_names
   return(demes)

--- a/R/validate_demes.R
+++ b/R/validate_demes.R
@@ -359,8 +359,41 @@ validate_demes <- function(inp){
     }
   }
 
-  if (is.null(inp$pulses)){
+  # Pulses
+  pulse_times <- c()
+  if (length(inp$pulses) == 0 | is.null(inp$pulses)){
     out$pulses <- list()
+  } else {
+    for (i in 1:length(inp$pulses)){
+      # Sources
+      if (is.null(inp$pulses[[i]]$sources) & !is.null(inp$defaults$pulse$sources)){
+        out$pulses[[i]]$sources <- inp$defaults$pulse$sources
+      } else if (is.null(inp$pulses[[i]]$sources)){
+        stop(paste("No sources were found for pulse", i, ". They are required for pulse resolution, however."), .call=F)
+      }
+      # Proportions
+      if (is.null(inp$pulses[[i]]$proportions) & !is.null(inp$defaults$pulse$proportions)){
+        out$pulses[[i]]$proportions <- inp$defaults$pulse$proportions
+      } else if (is.null(inp$pulses[[i]]$proportions)){
+        stop(paste("No proportions were found for pulse", i, ". They are required for pulse resolution, however."), .call=F)
+      }
+      # Dest
+      if (is.null(inp$pulses[[i]]$dest) & !is.null(inp$defaults$pulse$dest)){
+        out$pulses[[i]]$dest <- inp$defaults$pulse$dest
+      } else if (is.null(inp$pulses[[i]]$dest)){
+        stop(paste("No dest was found for pulse", i, ". It is required for pulse resolution, however."), .call=F)
+      }
+      # Time
+      if (is.null(inp$pulses[[i]]$time) & !is.null(inp$defaults$pulse$time)){
+        out$pulses[[i]]$time <- inp$defaults$pulse$time
+      } else if (is.null(inp$pulses[[i]]$time)){
+        stop(paste("No time was found for pulse", i, ". It is required for pulse resolution, however."), .call=F)
+      }
+      pulse_times[i] <- out$pulses[[i]]$time
+    }
+
+    # Sort pulses
+    out$pulses <- out$pulses[order(pulse_times, decreasing = TRUE)]
   }
 
   return(out)

--- a/R/validate_demes.R
+++ b/R/validate_demes.R
@@ -44,45 +44,75 @@ validate_demes <- function(inp){
       out$demes[[i]]$start_time <- as.double(inp$demes[[i]]$start_time)
     }
 
-    comparison_group <- c("end_time", "end_size", "start_size", "size_function", "selfing_rate", "cloning_rate")
+    if (length(inp$demes[[i]]$epochs) == 0){
+      inp$demes[[i]]$epochs <- list()
+      out$demes[[i]]$epochs <- list()
+    }
 
     if (length(inp$demes[[i]]$epochs) > 0){
-      for(j in 1:length(inp$demes[[i]]$epochs)){ # iterate through all epochs in deme i
-        inp_curr_epoch <- inp$demes[[i]]$epochs[[j]]
-        out_curr_epoch <- out$demes[[i]]$epochs[[j]]
+      num_epochs <- 1:length(inp$demes[[i]]$epochs)
+    } else {
+      num_epochs <- 1
+    }
+    for(j in num_epochs){ # iterate through all epochs in deme i
+      if (length(inp$demes[[i]]$epochs[j][[1]]) == 0){
+        inp$demes[[i]]$epochs[j][[1]] <- list()
+        out$demes[[i]]$epochs[j][[1]] <- list()
+      }
+      inp_curr_epoch <- inp$demes[[i]]$epochs[[j]]
+      out_curr_epoch <- out$demes[[i]]$epochs[[j]]
 
-        present_epoch <- c(names(inp_curr_epoch))
-        missing_epoch <- setdiff(comparison_group, present_epoch)
+      if (is.null(out_curr_epoch)){
+        out_curr_epoch <- list()
+      }
 
-        if (is.null(inp$demes[[i]]$epochs)){
-          # should probably throw an error, there should be at least one epoch per deme, right?
-          out_curr_epoch <- list()
-          out_curr_epoch$start_size <- as.double(0)
-          out_curr_epoch$end_size <- as.double(0)
-          out_curr_epoch$end_time <- as.double(0)
-          out_curr_epoch$size_function <- "constant"
+      # if(is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
+      #   out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
+      # } else if(!is.null(inp_curr_epoch$start_size) & is.null(inp_curr_epoch$end_size)){
+      #   out_curr_epoch$end_size <- as.double(inp_curr_epoch$start_size)
+      # } else if(!is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
+      #   out_curr_epoch$end_size <- as.double(inp_curr_epoch$end_size)
+      #   out_curr_epoch$start_size <- as.double(inp_curr_epoch$start_size)
+      # } else{
+      #   out_curr_epoch$end_size <- as.double(0)
+      #   out_curr_epoch$start_size <- as.double(0)
+      # }
 
-          out_curr_epoch$selfing_rate <- as.double(0)
-          out_curr_epoch$cloning_rate <- as.double(0)
+      if (is.null(out_curr_epoch$start_size)){
+        if (!is.null(inp$defaults$epoch$start_size)){
+          out_curr_epoch$start_size <- inp$defaults$epoch$start_size
+        } else if(!is.null(inp_curr_epoch$end_size))  {
+          out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
         } else {
+          out_curr_epoch$start_size <- as.double(0)
+        }
+      }
 
-          if (is.null(inp_curr_epoch$end_time)){
-            out_curr_epoch$end_time <- as.double(0)
-          }
 
-          if(is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-            out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
-          } else if(!is.null(inp_curr_epoch$start_size) & is.null(inp_curr_epoch$end_size)){
-            out_curr_epoch$end_size <- as.double(inp_curr_epoch$start_size)
-          } else if(!is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-            out_curr_epoch$end_size <- as.double(inp_curr_epoch$end_size)
-            out_curr_epoch$start_size <- as.double(inp_curr_epoch$start_size)
-          } else{
-            out_curr_epoch$end_size <- as.double(0)
-            out_curr_epoch$start_size <- as.double(0)
-          }
+      if (is.null(out_curr_epoch$end_size)){
+        if (!is.null(inp$defaults$epoch$end_size)){
+          out_curr_epoch$end_size <- inp$defaults$epoch$end_size
+        } else if(!is.null(out_curr_epoch$start_size))  {
+          out_curr_epoch$end_size <- as.double(out_curr_epoch$start_size)
+        } else {
+          out_curr_epoch$end_size <- as.double(0)
+        }
+      }
 
-          if(is.null(inp_curr_epoch$size_function)){
+
+      if (is.null(out_curr_epoch$end_time)){
+        if (!is.null(inp$defaults$epoch$end_time)){
+          out_curr_epoch$end_time <- inp$defaults$epoch$end_time
+        } else {
+          out_curr_epoch$end_time <- as.double(0)
+        }
+      }
+
+
+      if (is.null(out_curr_epoch$size_function)){
+        if (!is.null(inp$defaults$epoch$size_function)){
+          out_curr_epoch$size_function <- inp$defaults$epoch$size_function
+        } else {
             # size_function
             #
             # A function describing the population size change between start_time and end_time. This may be any string, but the values “constant” and “exponential” are explicitly acknowledged to have the following meanings.
@@ -99,25 +129,28 @@ validate_demes <- function(inp){
             } else{
               out_curr_epoch$size_function <- "exponential" # xxx quick fix
             }
-
           }
+        }
 
-          if(is.null(inp_curr_epoch$selfing_rate)){
+        if (is.null(out_curr_epoch$selfing_rate)){
+          if (!is.null(inp$defaults$epoch$selfing_rate)){
+            out_curr_epoch$selfing_rate <- inp$defaults$epoch$selfing_rate
+          } else {
             out_curr_epoch$selfing_rate <- as.double(0)
-          } else {
-            out_curr_epoch$selfing_rate <- as.double(inp_curr_epoch$selfing_rate)
           }
+        }
 
-          if(is.null(inp_curr_epoch$cloning_rate)){
-            out_curr_epoch$cloning_rate <- as.double(0)
+        if (is.null(out_curr_epoch$cloning_rate)){
+          if (!is.null(inp$defaults$epoch$cloning_rate)){
+            out_curr_epoch$cloning_rate <- inp$defaults$epoch$cloning_rate
           } else {
-            out_curr_epoch$cloning_rate <- as.double(inp_curr_epoch$cloning_rate)
+            out_curr_epoch$cloning_rate <- as.double(0)
           }
         }
 
         out$demes[[i]]$epochs[[j]] <- out_curr_epoch
       }
-    }
+
 
     if (is.null(inp$demes[[i]]$proportions) & length(inp$demes[[i]]$ancestors) == 1){
       out$demes[[i]]$proportions <- as.double(1)
@@ -130,10 +163,10 @@ validate_demes <- function(inp){
 
     if (is.null(inp$demes[[i]]$ancestors)){
       out$demes[[i]]$ancestors <- list()
+    } else {
+      out$demes[[i]]$ancestors <- inp$demes[[i]]$ancestors
     }
-
   }
-
 
   if (length(inp$migrations) == 0){
     out$migrations <- list()

--- a/R/validate_demes.R
+++ b/R/validate_demes.R
@@ -392,7 +392,7 @@ validate_migration_times <- function(out, i, time, deme_names){
       source_index <- match(out$migrations[[i]]$source, deme_names)
       dest_index <- match(out$migrations[[i]]$dest, deme_names)
       source_last_epoch <- length(out$demes[[source_index]]$epochs)
-      dest_last_epoch <- length(out$demes[[source_index]]$epochs)
+      dest_last_epoch <- length(out$demes[[dest_index]]$epochs)
 
       end_time <- as.double(
         max(out$demes[[source_index]]$epoch[[source_last_epoch]]$end_time,

--- a/R/validate_demes.R
+++ b/R/validate_demes.R
@@ -3,13 +3,15 @@ validate_demes <- function(inp){
 
   # Check for time_units and generation_time
   if (is.null(inp$time_units)){
-    out$time_units <- "generations"
+    stop("time_units must be specified but was missing.", .call = FALSE)
   }
 
-  if (is.null(inp$generation_time)){
+  if (is.null(inp$generation_time) & out$time_units == "generations"){
     out$generation_time <- as.double(1)
+  } else if(out$time_units == "generations" & out$generation_time != 1) {
+    stop("When time_units is 'generations', generation_time must be equal to 1 and can be omitted.", .call = FALSE)
   } else {
-    out$generation_time <- as.double(out$generation_time)
+    stop("generation_time must be specified, unless time_units is 'generations'.", .call = FALSE)
   }
 
 
@@ -26,24 +28,72 @@ validate_demes <- function(inp){
     names(out$metadata) <- character()
   }
 
+  # Attempting to validate top-level defaults insofar as possible
+  if (inp$defaults$epoch$start_size < 0){
+    stop("Epoch start_size cannot be negative, but a negative top-level default value was specified.", .call=FALSE)
+  }
+
+  # Demes validation
+  # Attempting to validate deme-level defaults insofar as possible
+  if (inp$demes$defaults$epoch$start_size < 0){
+    stop("Epoch start_size cannot be negative, but a negative deme-level default value was specified.", .call=FALSE)
+  }
+
   for (i in 1:length(inp$demes)){
-
+    # Name
     if (is.null(inp$demes[[i]]$name)){
-      # Throw error?
-      out$demes[[i]]$name <-  ''
+      stop(paste("Every deme must have a name, but deme", i, "does not have one.", .call=F))
     }
 
-    # Check for description or set default
-    if (is.null(inp$demes[[i]]$description)){
-      out$demes[[i]]$description <-  ''
+    # Description
+    if (is.null(inp$demes[[i]]$description) & !is.null(inp$defaults$deme$description)){
+      out$demes[[i]]$description <- inp$defaults$deme$description
+    } else {
+      out$demes[[i]]$description <- ""
     }
 
+    # Ancestors
+    if (is.null(inp$demes[[i]]$ancestors) & !is.null(inp$defaults$deme$ancestors)){
+      out$demes[[i]]$ancestors <- inp$defaults$deme$ancestors
+    } else {
+      out$demes[[i]]$ancestors <- list()
+    }
+
+    # Proportions
+    if (is.null(inp$demes[[i]]$proportions) & !is.null(inp$defaults$deme$proportions)){
+      out$demes[[i]]$proportions <- inp$defaults$deme$proportions
+    } else if (is.null(inp$demes[[i]]$proportions)){
+      if (length(inp$demes[[i]]$ancestors) == 1){
+        out$demes[[i]]$proportions <- list(as.double(1))
+      } else if(length(inp$demes[[i]]$ancestors) == 0){
+        out$demes[[i]]$proportions <- list()
+      } else{
+        stop("proportions cannot be determined with the information provided. proportions must either be specified explicitly, via defaults or have one or less ancestors.", .call=FALSE)
+      }
+    } else{
+      out$demes[[i]]$proportions <- as.double(inp$demes[[i]]$proportions)
+    }
+
+    # Start time
     if (is.null(inp$demes[[i]]$start_time)){
-      out$demes[[i]]$start_time <-  Inf
+      if(!is.null(inp$demes$defaults$start_time)){
+        out$demes[[i]]$start_time <-  inp$demes$defaults$start_time
+      } else if (!is.null(inp$defaults$demes$start_time)){
+        out$demes[[i]]$start_time <-  inp$defaults$demes$start_time
+      } else if (!is.null(inp$defaults$epoch$start_time)){
+        out$demes[[i]]$start_time <-  inp$defaults$epoch$start_time
+      } else if (length(out$demes[[i]]$ancestors) == 1 & out$demes[[out$demes[[i]]$ancestors[[1]]]]$end_time > 0){
+        out$demes[[i]]$start_time <- out$demes[[out$demes[[i]]$ancestors[[1]]]]$end_time
+      } else if (length(out$demes[[i]]$ancestors) == 0){
+        out$demes[[i]]$start_time <- Inf
+      } else {
+        stop(paste("start_time of deme", i, "cannot be determined from the provided information."), .call=FALSE)
+      }
     } else {
       out$demes[[i]]$start_time <- as.double(inp$demes[[i]]$start_time)
     }
 
+    # Epochs
     if (length(inp$demes[[i]]$epochs) == 0){
       inp$demes[[i]]$epochs <- list()
       out$demes[[i]]$epochs <- list()
@@ -54,6 +104,7 @@ validate_demes <- function(inp){
     } else {
       num_epochs <- 1
     }
+
     for(j in num_epochs){ # iterate through all epochs in deme i
       if (length(inp$demes[[i]]$epochs[j][[1]]) == 0){
         inp$demes[[i]]$epochs[j][[1]] <- list()
@@ -66,115 +117,235 @@ validate_demes <- function(inp){
         out_curr_epoch <- list()
       }
 
-      # if(is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-      #   out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
-      # } else if(!is.null(inp_curr_epoch$start_size) & is.null(inp_curr_epoch$end_size)){
-      #   out_curr_epoch$end_size <- as.double(inp_curr_epoch$start_size)
-      # } else if(!is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-      #   out_curr_epoch$end_size <- as.double(inp_curr_epoch$end_size)
-      #   out_curr_epoch$start_size <- as.double(inp_curr_epoch$start_size)
-      # } else{
-      #   out_curr_epoch$end_size <- as.double(0)
-      #   out_curr_epoch$start_size <- as.double(0)
-      # }
+      # Epoch start time
+      if (j == 1){
+        out_curr_epoch$start_time <- out$demes[[i]]$start_time
+      } else {
+        out_curr_epoch$start_time <- out$demes[[i]]$epochs[[j-1]]$end_time
+      }
 
-      if (is.null(out_curr_epoch$start_size)){
+      # Epoch end time
+      if (is.null(out_curr_epoch$end_time)){
+        if (!is.null(inp$demes$defaults$epoch$end_time)){
+          out_curr_epoch$end_time <- inp$demes$defaults$epoch$end_time
+        } else if (!is.null(inp$defaults$epoch$end_time)){
+          out_curr_epoch$end_time <- inp$defaults$epoch$end_time
+        } else if (j == length(out$demes[[i]]$epochs)) {
+          out_curr_epoch$end_time <- as.double(0)
+        } else {
+          stop(paste("Epoch end_time", j, "in deme", i, "cannot be determined."), .call=FALSE)
+        }
+      } else if (out_curr_epoch$end_time >= out$demes[[i]]$start_time){
+        stop(paste("The end_time of epoch", j, "is larger or equal to the start_time of deme", i, "but needs to be strictly smaller."), .call=FALSE)
+      } else if (j > 1 & out_curr_epoch$end_time >= out$demes[[i]]$epochs[[j-1]]$end_time){
+        stop(paste("The end_time values of successive epochs must be strictly decreasing, but in deme", i, "epoch", j, "is larger or equal to the end_time of epoch", j-1, "."), .call=FALSE)
+      }
+
+      # Epoch start size and end size
+      if (is.null(out_curr_epoch$start_size)){ # Resolve start size defaults
         if (!is.null(inp$defaults$epoch$start_size)){
           out_curr_epoch$start_size <- inp$defaults$epoch$start_size
-        } else if(!is.null(inp_curr_epoch$end_size))  {
-          out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
-        } else {
-          out_curr_epoch$start_size <- as.double(0)
+        } else if (!is.null(inp$demes$defaults$epoch$start_size)){
+          out_curr_epoch$start_size <- inp$demes$defaults$epoch$start_size
         }
       }
 
-
-      if (is.null(out_curr_epoch$end_size)){
+      if (is.null(out_curr_epoch$end_size)){ # Resolve end size defaults
         if (!is.null(inp$defaults$epoch$end_size)){
           out_curr_epoch$end_size <- inp$defaults$epoch$end_size
-        } else if(!is.null(out_curr_epoch$start_size))  {
-          out_curr_epoch$end_size <- as.double(out_curr_epoch$start_size)
-        } else {
-          out_curr_epoch$end_size <- as.double(0)
+        } else if (!is.null(inp$demes$defaults$epoch$end_size)){
+          out_curr_epoch$end_size <- inp$demes$defaults$epoch$end_size
         }
       }
 
+      if (j == 1){
+        if (is.null(out_curr_epoch$end_size) & is.null(out_curr_epoch$start_size)){
+          stop(paste("In the first epoch in each deme, at least one of start_size or end_size must be specified, possibly via default values. In deme", i, "both values were missing."), .call=FALSE)
+        } else if (is.null(out_curr_epoch$start_size)){
+          out_curr_epoch$start_size <- out_curr_epoch$end_size
+        } else if (is.null(out_curr_epoch$end_size)){
+          out_curr_epoch$end_size <- out_curr_epoch$start_size
+        }
 
-      if (is.null(out_curr_epoch$end_time)){
-        if (!is.null(inp$defaults$epoch$end_time)){
-          out_curr_epoch$end_time <- inp$defaults$epoch$end_time
-        } else {
-          out_curr_epoch$end_time <- as.double(0)
+        if (out$demes[[i]]$start_time == Inf & out_curr_epoch$start_size != out_curr_epoch$end_size){
+          stop(paste("If a deme has an infinite start_time, its first epoch must have identical start and end sizes, but in deme", i, "this is violated."), .call=FALSE)
+        }
+      } else {
+        if (is.null(out_curr_epoch$start_size)){
+          out_curr_epoch$start_size <- out$demes[[i]]$epochs[[j-1]]$end_size
+        }
+        if (is.null(out_curr_epoch$end_size)){
+          out_curr_epoch$end_size <- out_curr_epoch$start_size
         }
       }
 
-
+      # Size function
       if (is.null(out_curr_epoch$size_function)){
-        if (!is.null(inp$defaults$epoch$size_function)){
+        if (!is.null(inp$demes$defaults$epoch$size_function)){
+          out_curr_epoch$size_function <- inp$demes$defaults$epoch$size_function
+        } else if (!is.null(inp$defaults$epoch$size_function)){
           out_curr_epoch$size_function <- inp$defaults$epoch$size_function
         } else {
-            # size_function
-            #
-            # A function describing the population size change between start_time and end_time. This may be any string, but the values “constant” and “exponential” are explicitly acknowledged to have the following meanings.
-            #
-            # constant: the deme’s size does not change over the epoch. start_size and end_size must be equal.
-            # exponential: the deme’s size changes exponentially from start_size to end_size over the epoch. If t is a time within the span of the epoch, the deme size N at time t can be calculated as:
-            #   dt = (epoch.start_time - t) / (epoch.start_time - epoch.end_time)
-            # r = log(epoch.end_size / epoch.start_size)
-            # N = epoch.start_size * exp(r * dt)
-            #
             # size_function must be constant if the epoch has an infinite start_time.
             if(out_curr_epoch$end_size == out_curr_epoch$start_size){
               out_curr_epoch$size_function <- "constant"
             } else{
-              out_curr_epoch$size_function <- "exponential" # xxx quick fix
+              out_curr_epoch$size_function <- "exponential"
             }
-          }
         }
-
-        if (is.null(out_curr_epoch$selfing_rate)){
-          if (!is.null(inp$defaults$epoch$selfing_rate)){
-            out_curr_epoch$selfing_rate <- inp$defaults$epoch$selfing_rate
-          } else {
-            out_curr_epoch$selfing_rate <- as.double(0)
-          }
-        }
-
-        if (is.null(out_curr_epoch$cloning_rate)){
-          if (!is.null(inp$defaults$epoch$cloning_rate)){
-            out_curr_epoch$cloning_rate <- inp$defaults$epoch$cloning_rate
-          } else {
-            out_curr_epoch$cloning_rate <- as.double(0)
-          }
-        }
-
-        out$demes[[i]]$epochs[[j]] <- out_curr_epoch
       }
 
+      if (out_curr_epoch$start_time == Inf & out_curr_epoch$size_function != "constant"){
+        stop(paste("If epoch start_time infinite, the size_function must be constant. In deme", i, "epoch", j, "the size function is", out_curr_epoch$size_function, "instead."), .call=FALSE)
+      }
 
-    if (is.null(inp$demes[[i]]$proportions) & length(inp$demes[[i]]$ancestors) == 1){
-      out$demes[[i]]$proportions <- as.double(1)
-    } else if(is.null(inp$demes[[i]]$proportions) & length(inp$demes[[i]]$ancestors) > 1){
-      # Throw error?
-      print("no proportions even though several ancestors, that can't be right")
-    }else{
-      out$demes[[i]]$proportions <- as.double(unlist(inp$demes[[i]]$proportions))
-    }
+      # Selfing rate
+      if (is.null(out_curr_epoch$selfing_rate)){
+        if (!is.null(inp$demes$defaults$epoch$selfing_rate)){
+          out_curr_epoch$selfing_rate <- inp$demes$defaults$epoch$selfing_rate
+        } else if (!is.null(inp$defaults$epoch$selfing_rate)){
+          out_curr_epoch$selfing_rate <- inp$defaults$epoch$selfing_rate
+        } else {
+          out_curr_epoch$selfing_rate <- as.double(0)
+        }
+      }
 
-    if (is.null(inp$demes[[i]]$ancestors)){
-      out$demes[[i]]$ancestors <- list()
-    } else {
-      out$demes[[i]]$ancestors <- inp$demes[[i]]$ancestors
+        # Cloning rate
+      if (is.null(out_curr_epoch$cloning_rate)){
+        if (!is.null(inp$demes$defaults$epoch$cloning_rate)){
+          out_curr_epoch$cloning_rate <- inp$demes$defaults$epoch$cloning_rate
+        } else if (!is.null(inp$defaults$epoch$cloning_rate)){
+          out_curr_epoch$cloning_rate <- inp$defaults$epoch$cloning_rate
+        } else {
+          out_curr_epoch$cloning_rate <- as.double(0)
+        }
+      }
+
+      out$demes[[i]]$epochs[[j]] <- out_curr_epoch
     }
   }
 
+  out <- name_demes(out)
+
+  # Migrations
   if (length(inp$migrations) == 0){
     out$migrations <- list()
   } else {
-    for (i in 1:length(inp$migrations)){
-      out$migrations[[i]]$start_time <- as.double(out$migrations[[i]]$start_time)
-      out$migrations[[i]]$end_time <- as.double(out$migrations[[i]]$end_time)
-      out$migrations[[i]]$rate <- as.double(out$migrations[[i]]$rate)
+    start_num_migr <- length(inp$migrations)
+    for (i in 1:length(start_num_migr)){
+      # Rate
+      if (is.null(out$migrations[[i]]$rate) & !is.null(inp$defaults$migrations$rate)){
+        out$migrations[[i]]$rate <- inp$defaults$migrations$rate
+      } else if (is.null(out$migrations[[i]]$rate)){
+        stop(paste0("If a migration is specified, a migration rate must be specified, possibly via default values. This is violated in migration", i, "."), .call=FALSE)
+      } else {
+        out$migrations[[i]]$rate <- as.double(out$migrations[[i]]$rate)
+      }
+
+      if (sum(out$migrations[[i]]$rate) > 1){
+        stop(paste0("Sum of migration rates must be less than or equal to 1, violated in demes$migration[[", i, "]]."), call. = FALSE)
+      }
+
+      # Source
+      if (is.null(out$migrations[[i]]$source) & !is.null(inp$defaults$migrations$source)){
+        out$migrations[[i]]$source <- inp$defaults$migrations$source
+      }
+
+      # Dest
+      if (is.null(out$migrations[[i]]$dest) & !is.null(inp$defaults$migrations$dest)){
+        out$migrations[[i]]$dest<- inp$defaults$migrations$dest
+      }
+
+      # if (!(out$migrations[[i]]$dest %in% names(out$demes) ))
+      # TODO: Throw error if dest / source does not match a population
+
+      # Demes
+      if (is.null(out$migrations[[i]]$demes) & !is.null(inp$defaults$migrations$demes)){
+        out$migrations[[i]]$demes <- inp$defaults$migrations$demes
+      }
+
+      # Mode of migration
+      if (is.null(out$migrations[[i]]$demes) & !is.null(out$migrations[[i]]$dest) & !is.null(out$migrations[[i]]$source)){
+        migr_mode <- "asymmetric"
+      } else if (!is.null(out$migrations[[i]]$demes) & is.null(out$migrations[[i]]$dest) & is.null(out$migrations[[i]]$source)){
+        migr_mode <- "asymmetric"
+      } else {
+        stop(paste("Mode of migration (either symmetric or asymmetric) could not be determined for migration", i, ". For asymmetric migration,
+                   'dest' and 'source' must be specified and 'demes' must be NULL and for symmetric migration it is the other way around."), .call=FALSE)
+      }
+
+      # Symmetric Migration
+      if (migr_mode == "symmetric"){
+        if (length(out$migrations[[i]]$demes) < 2){
+          stop(paste("Symmetric migration requires at least two populations to be specified in 'migrations$demes', but fewer than 2 populations were specified for symmetric migration in migration", i, ". This cannot be resolved."), .call=FALSE)
+        } else if (length(out$migrations[[i]]$demes) != length(unique(out$migrations[[i]]$demes))){
+          stop(paste("Symmetric migration requires distinct populations to be specified in 'migrations$demes', but in migration", i, " not all population names were unique."), .call=FALSE)
+        } else if (!all(out$migrations[[i]]$demes %in% names(out$demes))){
+          stop(paste("Symmetric migration requires all specified populations to correspond to resolved demes. This was not the case in migration", i, ", where populations", out$migrations[[i]]$demes[out$migrations[[i]]$demes %in% names(out$demes)], "did not correspond to defined demes."), .call=FALSE)
+        }
+
+        # Saving symmetric migration at pos i and resetting migration at pos i
+        sym_migration <- out$migrations[[i]]
+        out$migrations[[i]] <- NULL
+        sym_combs <- combn(out$migrations[[i]]$demes, 2) # Getting all combinations
+
+        for (k in ncol(sym_combs)){
+          if (k == 1){ # The very first asymmetric migration replaces the original symmetric migration
+            # First asymmetric migration of pair
+            out$migrations[[i]]$source <- sym_combs[1, k]
+            out$migrations[[i]]$dest <- sym_combs[2, k]
+            out$migrations[[i]]$rate <- sym_migration$rate
+            out$migrations[[i]]$start_time <- sym_migration$start_time
+            out$migrations[[i]]$end_time <- sym_migration$end_time
+            # start_time
+            out$migrations[[i]]$start_time <- validate_migration_times(out, i, time="start")
+            # end_time
+            out$migrations[[i]]$end_time <- validate_migration_times(out, i, time="end")
+
+            # Second asymmetric migration of pair
+            pos_counter <- length(out$migrations)+1
+            out$migrations[[pos_counter]]$dest <- sym_combs[1, k]
+            out$migrations[[pos_counter]]$source <- sym_combs[2, k]
+            out$migrations[[pos_counter]]$rate <- sym_migration$rate
+            out$migrations[[pos_counter]]$start_time <- sym_migration$start_time
+            out$migrations[[pos_counter]]$end_time <- sym_migration$end_time
+            # start_time
+            out$migrations[[i]]$start_time <- validate_migration_times(out, pos_counter, time="start")
+            # end_time
+            out$migrations[[i]]$end_time <- validate_migration_times(out, pos_counter, time="end")
+
+          } else {
+            pos_counter <- pos_counter + 1
+            # First asymmetric migration of pair
+            out$migrations[[pos_counter]]$source <- sym_combs[1, k]
+            out$migrations[[pos_counter]]$dest <- sym_combs[2, k]
+            out$migrations[[pos_counter]]$rate <- sym_migration$rate
+            out$migrations[[pos_counter]]$start_time <- sym_migration$start_time
+            out$migrations[[pos_counter]]$end_time <- sym_migration$end_time
+            # start_time
+            out$migrations[[i]]$start_time <- validate_migration_times(out, pos_counter, time="start")
+            # end_time
+            out$migrations[[i]]$end_time <- validate_migration_times(out, pos_counter, time="end")
+
+            pos_counter <- pos_counter + 1
+            # Second asymmetric migration of pair
+            out$migrations[[pos_counter]]$dest <- sym_combs[1, k]
+            out$migrations[[pos_counter]]$source <- sym_combs[2, k]
+            out$migrations[[pos_counter]]$rate <- sym_migration$rate
+            out$migrations[[pos_counter]]$start_time <- sym_migration$start_time
+            out$migrations[[pos_counter]]$end_time <- sym_migration$end_time
+            # start_time
+            out$migrations[[i]]$start_time <- validate_migration_times(out, pos_counter, time="start")
+            # end_time
+            out$migrations[[i]]$end_time <- validate_migration_times(out, pos_counter, time="end")
+          }
+        }
+      } else { # asymmetric migrations
+        # start_time
+        out$migrations[[i]]$start_time <- validate_migration_times(out, i, time="start")
+        # end_time
+        out$migrations[[i]]$end_time <- validate_migration_times(out, i, time="end")
+      }
     }
   }
 
@@ -185,3 +356,30 @@ validate_demes <- function(inp){
   return(out)
 }
 
+
+
+validate_migration_times <- function(out, i, time){
+  if (time == "start"){
+    if (!is.null(out$migrations[[i]]$start_time)){
+      start_time <- as.double(out$migrations[[i]]$start_time)
+    } else if (!is.null(out$defaults$migration$start_time)) {
+      start_time <- as.double(out$defaults$migration$start_time)
+    } else {
+      start_time <- as.double(
+        min(out$demes$demes[[out$migrations[[i]]$source]]$start_time,
+            out$demes$demes[[out$migrations[[i]]$dest]]$start_time))
+    }
+    return(start_time)
+  } else if (time == "end"){
+    if (!is.null(out$migrations[[i]]$end_time)){
+      end_time <- as.double(out$migrations[[i]]$end_time)
+    } else if (!is.null(out$defaults$migration$end_time)) {
+      end_time <- as.double(out$defaults$migration$end_time)
+    } else {
+      end_time <- as.double(
+        max(out$demes$demes[[out$migrations[[i]]$source]]$end_time,
+            out$demes$demes[[out$migrations[[i]]$dest]]$end_time))
+    }
+    return(end_time)
+  }
+}

--- a/R/validate_demes.R
+++ b/R/validate_demes.R
@@ -46,73 +46,77 @@ validate_demes <- function(inp){
 
     comparison_group <- c("end_time", "end_size", "start_size", "size_function", "selfing_rate", "cloning_rate")
 
-    for(j in 1:length(inp$demes[[i]]$epochs)){ # iterate through all epochs in deme i
-      inp_curr_epoch <- inp$demes[[i]]$epochs[[j]]
-      out_curr_epoch <- out$demes[[i]]$epochs[[j]]
+    if (length(inp$demes[[i]]$epochs) > 0){
+      for(j in 1:length(inp$demes[[i]]$epochs)){ # iterate through all epochs in deme i
+        inp_curr_epoch <- inp$demes[[i]]$epochs[[j]]
+        out_curr_epoch <- out$demes[[i]]$epochs[[j]]
 
-      present_epoch <- c(names(inp_curr_epoch))
-      missing_epoch <- setdiff(comparison_group, present_epoch)
+        present_epoch <- c(names(inp_curr_epoch))
+        missing_epoch <- setdiff(comparison_group, present_epoch)
 
-      if (is.null(inp$demes[[i]]$epochs)){
-        # should probably throw an error, there should be at least one epoch per deme, right?
-        out_curr_epoch <- list()
-        out_curr_epoch$start_size <- as.double(0)
-        out_curr_epoch$end_size <- as.double(0)
-        out_curr_epoch$end_time <- as.double(0)
-        out_curr_epoch$size_function <- "constant"
-
-        out_curr_epoch$selfing_rate <- as.double(0)
-        out_curr_epoch$cloning_rate <- as.double(0)
-      } else {
-
-        if (is.null(inp_curr_epoch$end_time)){
+        if (is.null(inp$demes[[i]]$epochs)){
+          # should probably throw an error, there should be at least one epoch per deme, right?
+          out_curr_epoch <- list()
+          out_curr_epoch$start_size <- as.double(0)
+          out_curr_epoch$end_size <- as.double(0)
           out_curr_epoch$end_time <- as.double(0)
-        }
+          out_curr_epoch$size_function <- "constant"
 
-        if(is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-          out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
-        } else if(!is.null(inp_curr_epoch$start_size) & is.null(inp_curr_epoch$end_size)){
-          out_curr_epoch$end_size <- as.double(inp_curr_epoch$start_size)
-        } else if(!is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
-          out_curr_epoch$end_size <- as.double(inp_curr_epoch$end_size)
-          out_curr_epoch$start_size <- as.double(inp_curr_epoch$start_size)
-        }
-
-        if(is.null(inp_curr_epoch$size_function)){
-          # This is a quick fix, test file args_from_file_01.yaml suggests that the size function is calculated from the size values?
-          # size_function
-          #
-          # A function describing the population size change between start_time and end_time. This may be any string, but the values “constant” and “exponential” are explicitly acknowledged to have the following meanings.
-          #
-          # constant: the deme’s size does not change over the epoch. start_size and end_size must be equal.
-          # exponential: the deme’s size changes exponentially from start_size to end_size over the epoch. If t is a time within the span of the epoch, the deme size N at time t can be calculated as:
-          #   dt = (epoch.start_time - t) / (epoch.start_time - epoch.end_time)
-          # r = log(epoch.end_size / epoch.start_size)
-          # N = epoch.start_size * exp(r * dt)
-          #
-          # size_function must be constant if the epoch has an infinite start_time.
-          if(out_curr_epoch$end_size == out_curr_epoch$start_size){
-            out_curr_epoch$size_function <- "constant"
-          } else{
-            out_curr_epoch$size_function <- "exponential" # xxx quick fix
-          }
-
-        }
-
-        if(is.null(inp_curr_epoch$selfing_rate)){
           out_curr_epoch$selfing_rate <- as.double(0)
-        } else {
-          out_curr_epoch$selfing_rate <- as.double(inp_curr_epoch$selfing_rate)
-        }
-
-        if(is.null(inp_curr_epoch$cloning_rate)){
           out_curr_epoch$cloning_rate <- as.double(0)
         } else {
-          out_curr_epoch$cloning_rate <- as.double(inp_curr_epoch$cloning_rate)
-        }
-      }
 
-      out$demes[[i]]$epochs[[j]] <- out_curr_epoch
+          if (is.null(inp_curr_epoch$end_time)){
+            out_curr_epoch$end_time <- as.double(0)
+          }
+
+          if(is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
+            out_curr_epoch$start_size <- as.double(inp_curr_epoch$end_size)
+          } else if(!is.null(inp_curr_epoch$start_size) & is.null(inp_curr_epoch$end_size)){
+            out_curr_epoch$end_size <- as.double(inp_curr_epoch$start_size)
+          } else if(!is.null(inp_curr_epoch$start_size) & !is.null(inp_curr_epoch$end_size)){
+            out_curr_epoch$end_size <- as.double(inp_curr_epoch$end_size)
+            out_curr_epoch$start_size <- as.double(inp_curr_epoch$start_size)
+          } else{
+            out_curr_epoch$end_size <- as.double(0)
+            out_curr_epoch$start_size <- as.double(0)
+          }
+
+          if(is.null(inp_curr_epoch$size_function)){
+            # size_function
+            #
+            # A function describing the population size change between start_time and end_time. This may be any string, but the values “constant” and “exponential” are explicitly acknowledged to have the following meanings.
+            #
+            # constant: the deme’s size does not change over the epoch. start_size and end_size must be equal.
+            # exponential: the deme’s size changes exponentially from start_size to end_size over the epoch. If t is a time within the span of the epoch, the deme size N at time t can be calculated as:
+            #   dt = (epoch.start_time - t) / (epoch.start_time - epoch.end_time)
+            # r = log(epoch.end_size / epoch.start_size)
+            # N = epoch.start_size * exp(r * dt)
+            #
+            # size_function must be constant if the epoch has an infinite start_time.
+            if(out_curr_epoch$end_size == out_curr_epoch$start_size){
+              out_curr_epoch$size_function <- "constant"
+            } else{
+              out_curr_epoch$size_function <- "exponential" # xxx quick fix
+            }
+
+          }
+
+          if(is.null(inp_curr_epoch$selfing_rate)){
+            out_curr_epoch$selfing_rate <- as.double(0)
+          } else {
+            out_curr_epoch$selfing_rate <- as.double(inp_curr_epoch$selfing_rate)
+          }
+
+          if(is.null(inp_curr_epoch$cloning_rate)){
+            out_curr_epoch$cloning_rate <- as.double(0)
+          } else {
+            out_curr_epoch$cloning_rate <- as.double(inp_curr_epoch$cloning_rate)
+          }
+        }
+
+        out$demes[[i]]$epochs[[j]] <- out_curr_epoch
+      }
     }
 
     if (is.null(inp$demes[[i]]$proportions) & length(inp$demes[[i]]$ancestors) == 1){

--- a/inst/extdata/yaml/several_demes_01.yaml
+++ b/inst/extdata/yaml/several_demes_01.yaml
@@ -1,0 +1,11 @@
+time_units: generations
+demes:
+  - name: a
+    epochs:
+    - start_size: 100
+  - name: b
+    epochs:
+    - start_size: 100
+  - name: c
+    epochs:
+    - start_size: 100

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -46,7 +46,12 @@ parse_ref <- function(input_file){
   return(path_preparsed_file)
 }
 
-# Get path to a test file in the Demes specification directory
+# Get path to a valid test file in the Demes specification directory
 get_test_file <- function(file) {
   file.path(get_spec_dir(), "test-cases", "valid", file)
+}
+
+# Get path to an invalid test file in the Demes specification directory
+get_invalid_test_file <- function(file) {
+  file.path(get_spec_dir(), "test-cases", "invalid", file)
 }

--- a/tests/testthat/test-name_demes.R
+++ b/tests/testthat/test-name_demes.R
@@ -1,11 +1,22 @@
-test_that("loaded demes are named correctly", {
-  # d <- yaml::read_yaml(test_path("data", "valid", "minimal_01.yaml"))
+test_that("one deme is named correctly", {
   d <- yaml::read_yaml(system.file("extdata/yaml", "minimal_01.yaml", package = "demes"))
   d <- validate_demes(d)
   d <- name_demes(d)
 
   expect_identical(names(d$demes), c("a"))
   expect_identical(d$demes[[1]], d$demes$a)
+})
+
+test_that("several demes are named correctly", {
+  d <- yaml::read_yaml(system.file("extdata/yaml", "several_demes_01.yaml", package = "demes"))
+  d <- validate_demes(d)
+  d <- name_demes(d)
+
+  expected_names <- c(d$demes[[1]]$name, d$demes[[2]]$name, d$demes[[3]]$name)
+  expect_identical(names(d$demes), expected_names)
+  expect_identical(d$demes[[1]], d$demes$a)
+  expect_identical(d$demes[[2]], d$demes[[d$demes[[2]]$name]])
+  expect_identical(d$demes[[3]], d$demes[[d$demes[[3]]$name]])
 })
 
 # TODO: test on Demes YAML files with multiple populations

--- a/tests/testthat/test-read_demes.R
+++ b/tests/testthat/test-read_demes.R
@@ -1,6 +1,7 @@
 # TODO: this should be more extensive (perhaps extract this into a function and run
 # against multiple (or even all?) YAML files in the Demes spec repository)
 test_that("minimal_01.yaml is loaded correctly", {
+  setup_demes_spec()
   d <- read_demes(file = file.path(get_spec_dir(), "test-cases", "valid", "minimal_01.yaml"))
 
   # Test that all the expected list entries are present in the loaded
@@ -20,15 +21,16 @@ test_that("minimal_01.yaml is loaded correctly", {
   expect_equal(d$metadata, named_list)
   expect_equal(d$demes[[1]]$ancestors, list())
   expect_identical(d$demes[[1]]$description, '')
-  expect_equal(d$demes[[1]]$proportions, vector(mode="integer"))
+  expect_equal(d$demes[[1]]$proportions, list())
   expect_identical(d$migrations, list())
   expect_identical(d$pulses, list())
 })
 
 test_that("both input types work", {
+  setup_demes_spec()
   yaml_string <- "time_units: generations\ndemes:\n  - name: a\n    epochs:\n    - start_size: 100"
   a <- read_demes(text = yaml_string)
-  b <- read_demes(file = get_test_file("minimal_01.yaml"))
+  b <- read_demes(file = file.path(get_spec_dir(), "test-cases", "valid", "minimal_01.yaml"))
   expect_identical(order_demes(a), order_demes(b))
 })
 

--- a/tests/testthat/test-validate_demes.R
+++ b/tests/testthat/test-validate_demes.R
@@ -27,36 +27,15 @@ test_that("R parser results match the reference implementation in Python", {
   setup_env()
   setup_demes_spec()
 
-  # test_files <- list.files(get_test_file_path())
-  # test_files <- test_files[test_files == "minimal_01.yaml"]
-
   # get all valid test YAML files available in the Demes specification repository
-  # test_files <- file.path(get_spec_dir(), "test-cases", "valid") %>% list.files(pattern = ".yaml")
-  # test_files <- "basic_resolution_05.yaml"
-  test_files <- c(paste0("minimal_0", 1:2, ".yaml"),
-                  paste0("admixture_0", 1:9, ".yaml"), paste0("admixture_", 10:27, ".yaml"),
-                  paste0("deme_names_0", 1:3, ".yaml"),
-                  paste0("migration_0", 1:9, ".yaml"), "migration_10.yaml",
-                  paste0("structure_0", 1:8, ".yaml") ,
-                  "args_from_file_01.yaml",
-                  "admixture_and_split_01.yaml",
-                  "asymmetric_migration_01.yaml",
-                  "bad_pulse_time_01.yaml",
-                  paste0("deme_cloning_rate_0", 1:3, ".yaml"),
-                  "deme_selfing_rate_01.yaml",
-                  "size_function_defaults_01.yaml",
-                  paste0("split_0", 1:9, ".yaml"), "split_10.yaml",
-                  "selfing_cloning_01.yaml",
-                  paste0("size_changes_0", 1:9, ".yaml"), paste0("size_changes_", 10:32, ".yaml"),
-                  paste0("basic_resolution_0", 1:6, ".yaml"),
-                  paste0("deme_names_0", 1:3, ".yaml"),
-                  paste0("infinity_0", 1:8, ".yaml")
-                  )
-
+  test_files <- file.path(get_spec_dir(), "test-cases", "valid") %>% list.files(pattern = ".yaml")
+  # Remove files that cannot be parsed
+  # The first three don't pass because they have a deme named "y" and that is interpreted as TRUE in yaml 1.1 which is what the reader is based on
+  # For the last one it is the pre-parsed file that causes issues. It cannot be read by yaml::read_yaml without causing an error unless encoding UTF-16 is specified
+  test_files <- test_files[!(test_files %in% c("toplevel_defaults_deme_01.yaml", "successors_predecessors_01.yaml", "deme_end_time_01.yaml", "unicode_deme_name_04.yaml"))]
 
   for (f in test_files){
     path_preparsed_file <- parse_ref(get_test_file(f))
-    # print(path_preparsed_file)
 
     # validating a fully parsed model should not change anything
     # Use less strict expectation (as opposed to use_identical), because values should

--- a/tests/testthat/test-validate_demes.R
+++ b/tests/testthat/test-validate_demes.R
@@ -18,7 +18,7 @@ test_that("minimal_01.yaml is parsed correctly", {
   expect_equal(d$metadata, named_list)
   expect_equal(d$demes[[1]]$ancestors, list())
   expect_identical(d$demes[[1]]$description, '')
-  expect_equal(d$demes[[1]]$proportions, vector(mode="integer"))
+  expect_equal(d$demes[[1]]$proportions, list())
   expect_identical(d$migrations, list())
   expect_identical(d$pulses, list())
 })
@@ -32,6 +32,7 @@ test_that("R parser results match the reference implementation in Python", {
 
   # get all valid test YAML files available in the Demes specification repository
   # test_files <- file.path(get_spec_dir(), "test-cases", "valid") %>% list.files(pattern = ".yaml")
+  # test_files <- "basic_resolution_05.yaml"
   test_files <- c(paste0("minimal_0", 1:2, ".yaml"),
                   paste0("admixture_0", 1:9, ".yaml"), paste0("admixture_", 10:27, ".yaml"),
                   paste0("deme_names_0", 1:3, ".yaml"),
@@ -40,13 +41,16 @@ test_that("R parser results match the reference implementation in Python", {
                   "args_from_file_01.yaml",
                   "admixture_and_split_01.yaml",
                   "asymmetric_migration_01.yaml",
-                  "bad_pulse_time_01.yaml", # fails because defaults are not yet implemented
+                  "bad_pulse_time_01.yaml",
                   paste0("deme_cloning_rate_0", 1:3, ".yaml"),
                   "deme_selfing_rate_01.yaml",
                   "size_function_defaults_01.yaml",
                   paste0("split_0", 1:9, ".yaml"), "split_10.yaml",
                   "selfing_cloning_01.yaml",
-                  paste0("size_changes_0", 1:9, ".yaml"), paste0("size_changes_", 10:32, ".yaml")
+                  paste0("size_changes_0", 1:9, ".yaml"), paste0("size_changes_", 10:32, ".yaml"),
+                  paste0("basic_resolution_0", 1:6, ".yaml"),
+                  paste0("deme_names_0", 1:3, ".yaml"),
+                  paste0("infinity_0", 1:8, ".yaml")
                   )
 
 

--- a/tests/testthat/test-validate_demes.R
+++ b/tests/testthat/test-validate_demes.R
@@ -1,4 +1,5 @@
 test_that("minimal_01.yaml is parsed correctly", {
+  setup_demes_spec()
   inp <- yaml::read_yaml(get_test_file("minimal_01.yaml"))
   d <- validate_demes(inp)
 
@@ -32,21 +33,21 @@ test_that("R parser results match the reference implementation in Python", {
   # get all valid test YAML files available in the Demes specification repository
   # test_files <- file.path(get_spec_dir(), "test-cases", "valid") %>% list.files(pattern = ".yaml")
   test_files <- c(paste0("minimal_0", 1:2, ".yaml"),
-                                            paste0("admixture_0", 1:9, ".yaml"), paste0("admixture_", 10:27, ".yaml"),
-                                            paste0("deme_names_0", 1:3, ".yaml"),
-                                            paste0("migration_0", 1:9, ".yaml"), "migration_10.yaml",
-                                            paste0("structure_0", 1:8, ".yaml"),
-                                            "args_from_file_01.yaml",
-                                            "admixture_and_split_01.yaml",
-                                            "asymmetric_migration_01.yaml",
-                                            "bad_pulse_time_01.yaml",
-                                            paste0("deme_cloning_rate_0", 1:3, ".yaml"),
-                                            "deme_selfing_rate_01.yaml",
-                                            "size_function_defaults_01.yaml",
-                                            paste0("split_0", 1:9, ".yaml"), "split_10.yaml",
-                                            "selfing_cloning_01.yaml",
-                                            paste0("size_changes_0", 1:9, ".yaml"), paste0("size_changes_", 10:32, ".yaml")
-                                            )
+                  paste0("admixture_0", 1:9, ".yaml"), paste0("admixture_", 10:27, ".yaml"),
+                  paste0("deme_names_0", 1:3, ".yaml"),
+                  paste0("migration_0", 1:9, ".yaml"), "migration_10.yaml",
+                  paste0("structure_0", 1:8, ".yaml"),
+                  "args_from_file_01.yaml",
+                  "admixture_and_split_01.yaml",
+                  "asymmetric_migration_01.yaml",
+                  "bad_pulse_time_01.yaml",
+                  paste0("deme_cloning_rate_0", 1:3, ".yaml"),
+                  "deme_selfing_rate_01.yaml",
+                  "size_function_defaults_01.yaml",
+                  paste0("split_0", 1:9, ".yaml"), "split_10.yaml",
+                  "selfing_cloning_01.yaml",
+                  paste0("size_changes_0", 1:9, ".yaml"), paste0("size_changes_", 10:32, ".yaml")
+                  )
 
 
   for (f in test_files){

--- a/tests/testthat/test-validate_demes.R
+++ b/tests/testthat/test-validate_demes.R
@@ -16,9 +16,9 @@ test_that("minimal_01.yaml is parsed correctly", {
   named_list <- list()
   names(named_list) <- character()
   expect_equal(d$metadata, named_list)
-  expect_equal(d$demes[[1]]$ancestors, list())
+  expect_equal(d$demes[[1]]$ancestors, vector(mode="character"))
   expect_identical(d$demes[[1]]$description, '')
-  expect_equal(d$demes[[1]]$proportions, list())
+  expect_equal(d$demes[[1]]$proportions, vector(mode="double"))
   expect_identical(d$migrations, list())
   expect_identical(d$pulses, list())
 })
@@ -62,3 +62,17 @@ test_that("R parser results match the reference implementation in Python", {
   #       This is done to avoid type errors for users, when default values like 0, read as an integer by read_yaml() are changed interactively
   #   3) 1) and 2) mean that an extra processing step has to happen to the true comparison object in the testing
 })
+
+# test_that("R parser rejects all invalid test cases", {
+#   setup_demes_spec()
+#
+#   # get all invalid test YAML files available in the Demes specification repository
+#   test_files <- file.path(get_spec_dir(), "test-cases", "invalid") %>% list.files(pattern = ".yaml")
+#
+#   for (f in test_files){
+#     inp <- yaml::read_yaml(get_invalid_test_file(f))
+#     try(validate_demes(inp))
+#     print(f)
+#     expect_error(validate_demes(inp), label = f)
+#   }
+# })

--- a/tests/testthat/test-validate_demes.R
+++ b/tests/testthat/test-validate_demes.R
@@ -36,11 +36,11 @@ test_that("R parser results match the reference implementation in Python", {
                   paste0("admixture_0", 1:9, ".yaml"), paste0("admixture_", 10:27, ".yaml"),
                   paste0("deme_names_0", 1:3, ".yaml"),
                   paste0("migration_0", 1:9, ".yaml"), "migration_10.yaml",
-                  paste0("structure_0", 1:8, ".yaml"),
+                  paste0("structure_0", 1:8, ".yaml") ,
                   "args_from_file_01.yaml",
                   "admixture_and_split_01.yaml",
                   "asymmetric_migration_01.yaml",
-                  "bad_pulse_time_01.yaml",
+                  "bad_pulse_time_01.yaml", # fails because defaults are not yet implemented
                   paste0("deme_cloning_rate_0", 1:3, ".yaml"),
                   "deme_selfing_rate_01.yaml",
                   "size_function_defaults_01.yaml",


### PR DESCRIPTION
Except for these four valid test cases ("toplevel_defaults_deme_01.yaml", "successors_predecessors_01.yaml", "deme_end_time_01.yaml", "unicode_deme_name_04.yaml"), all valid test cases in the deme spec can now be parsed correctly and pass all tests. 

The files that cannot be parsed correctly are for reasons outside the validate_demes() function. The first three don't pass because they have a deme named "y" and that is interpreted as TRUE in yaml 1.1 which is what the yaml reader is based on. For the last one it is the pre-parsed file that causes issues. It cannot be read by yaml::read_yaml without causing an error unless fileEncoding = UTF-16 is specified.